### PR TITLE
Remove unnecessary interval check

### DIFF
--- a/BAMMtools/R/colorMap.R
+++ b/BAMMtools/R/colorMap.R
@@ -30,9 +30,6 @@ colorMap <- function(x, pal, breaks, logcolor = FALSE, color.interval = NULL) {
 		if (is.na(color.interval[2])) {
 			color.interval[2] <- max(x);
 		}
-		if (color.interval[1] < min(x) | color.interval[2] > max(x)) {
-			stop("Supplied color.interval is out of bounds.");
-		}
 		goodbreaks <- intersect(which(breaks > color.interval[1]), which(breaks < color.interval[2]));
 		topcolor <- colpalette[length(colpalette)];
 		bottomcolor <- colpalette[1];


### PR DESCRIPTION
If you want to color your rates outside of the range you should be allowed to. This makes it easier to program against BAMM to say, create a bunch of phylorate plots in a loop using the same color scale.