### PR TITLE
Add epsilon to prevent -Inf rates

### DIFF
--- a/BAMMtools/R/traitDependentBAMM.R
+++ b/BAMMtools/R/traitDependentBAMM.R
@@ -136,7 +136,7 @@ traitDependentBAMM <- function(ephy, traits, reps, rate = 'speciation', return.f
   }
 
 	if (logrates) {
-		tiprates <- lapply(1:length(tiprates), function(x){ log(tiprates[[x]]) });
+		tiprates <- lapply(1:length(tiprates), function(x){ log(tiprates[[x]] + .Machine$double.eps) });
 	}
 
 	#randomly sample generations from BAMM posterior


### PR DESCRIPTION
If you have a rate = 0 in trait dependent BAMM and you have `logrates = TRUE` you can get -Inf rates which are bad. Add a machine epsilon to prevent this from happening.