### PR TITLE
Actually use travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CRAN version](http://www.r-pkg.org/badges/version/rangeBuilder)](http://cran.rstudio.com/web/packages/BAMMtools/index.html)
-
+[![Build Status](https://travis-ci.org/josephwb/bammtools.svg?branch=master)](https://travis-ci.org/josephwb/bammtools)
 BAMMtools
 =========
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CRAN version](http://www.r-pkg.org/badges/version/rangeBuilder)](http://cran.rstudio.com/web/packages/BAMMtools/index.html)
-[![Build Status](https://travis-ci.org/josephwb/bammtools.svg?branch=master)](https://travis-ci.org/josephwb/bammtools)
+[![Build Status](https://travis-ci.org/macroevolution/bammtools.svg?branch=master)](https://travis-ci.org/macroevolution/bammtools)
 BAMMtools
 =========
 


### PR DESCRIPTION
While bammtools has a `.travis.yml` file, it is not clear that it is configured to run (or at least report the results). This PR adds a simple build status badge to the `README.md` file.
If travis is not yet "turned on", go [here](https://travis-ci.org/profile/macroevolution) and flip the switch on for `macroevolution/bamm` (I can not do this because I do not have admin privileges). Turning this on should be done before accepting the PR.
I've run this successfully in my fork (currently says "build unknown") because I switched the account over from mine to `macroevolution`.
With this, every push will instigate a build which will be checked by travis. Many more tests can eventually be added, but this is a first step.
HTH :bowtie: 