### PR TITLE
usable url

### DIFF
--- a/BAMMtools/man/BAMMtools-package.Rd
+++ b/BAMMtools/man/BAMMtools-package.Rd
@@ -25,7 +25,7 @@ Dan Rabosky, Mike Grundler, Pascal Title, Jonathan Mitchell, Carlos Anderson, Je
 Maintainer: {Pascal Title <ptitle@umich.edu}>
 }
 \references{
-\url{bamm-project.org}
+\url{http://bamm-project.org}
 
 Rabosky, D., M. Grundler, C. Anderson, P. Title, J. Shi, J. Brown, H. Huang and J. Larson. 2014. BAMMtools: an R package for the analysis of evolutionary dynamics on phylogenetic trees. Methods in Ecology and Evolution 5: 701-707.
 


### PR DESCRIPTION
Running `?BAMMtools` displays `BAMMtools-package.Rd`. As it is currently, the **References** lists "bamm-project.org". However, clicking on that displays:

>Only help files, NEWS, DESCRIPTION and files under doc/ and demo/ in a package can be viewed

And copying the link reveals that it is indeed "http://127.0.0.1:14474/help/library/BAMMtools/html/bamm-project.org". I've confirmed that this behaviour occurs in both mac/cran-gui and linux/rstudio.

This simple PR fixes the url, so clicking on it opens a browser to the intended, er, url.